### PR TITLE
Sampler pointset resize bugfix + more robust parsing in FindMultiArgs

### DIFF
--- a/src/core/cmdlnparser.h
+++ b/src/core/cmdlnparser.h
@@ -149,6 +149,8 @@ bool CLParser::FindMultiArgs(int nargs, vector<T>& argOut, const vector<string>&
 
             throw(invalid_argument("Did you forget to specify enough parameters after " + MultiArgsStr + "?: Expecting " + nstr)) ;
         }
+        else
+            throw (invalid_argument("Did you forget to specify " + MultiArgsStr + "?\n"));
     }
 
     if (nargs<0)

--- a/src/sampler/sampler.cpp
+++ b/src/sampler/sampler.cpp
@@ -199,7 +199,7 @@ void jitteredSampler::Sample(vector<Point2d> &pts, int n) const
     int sqrtN (floor(sqrt(n))) ;
     double dX(1.0f/(sqrtN)), dY(dX);
 
-    pts.resize(n) ;
+    pts.resize(sqrtN * sqrtN) ;
 
     double maxRange = bBoxMax - bBoxMin;
     std::random_device rd;
@@ -247,7 +247,7 @@ void gridSampler::Sample(vector<Point2d>& pts, int n) const
     int sqrtN (ceil(sqrt(n))) ;
     double dX(1.0f/(sqrtN)), dY(dX);
 
-    pts.resize(n) ;
+    pts.resize(sqrtN * sqrtN) ;
 
     for (int i=0; i<sqrtN; i++)
     {
@@ -284,7 +284,7 @@ void gjSampler::Sample(vector<Point2d>& pts, int n) const
 {
     int sqrtN (floor(sqrt(n))) ;
     double dX(1.0f/(sqrtN)), dY(dX);
-    pts.resize(n) ;
+    pts.resize(sqrtN * sqrtN) ;
     std::random_device rd;
 
     for (int i=0; i<sqrtN; i++)
@@ -330,7 +330,7 @@ void bjSampler::Sample(vector<Point2d>& pts, int n) const
 {
     int sqrtN (floor(sqrt(n))) ;
     double dX(1.0f/(sqrtN)), dY(dX);
-    pts.resize(n) ;
+    pts.resize(sqrtN * sqrtN) ;
     std::random_device rd;
 
     for (int i=0; i<sqrtN; i++)


### PR DESCRIPTION
When using a number of samples whose sqrt is not an integer, this results in uninitialised samples at (0,0).

When forgetting to state a flag when FindMultiArgs is called, this results in a segfault.

Both issues are fixed. Nonetheless, there remains an issue when stating the flag but forgetting to include enough parameters. The exception in the code meant for such cases is never reached.